### PR TITLE
Set generous CORS headers

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -87,6 +87,7 @@ export default class UnboxApp {
 
             // Pipe the unzipped file to body
             ctx.type = path.extname(file_path)
+            ctx.set('Access-Control-Allow-Origin', '*');
             ctx.body = this.cache.get_file(hash, file_path, details.type)
         }
         catch (err) {


### PR DESCRIPTION
This should be safe. https://jakearchibald.com/2021/cors/

> If a resource never contains private data, then it's totally safe to put Access-Control-Allow-Origin: * on it. Do it! Do it now!